### PR TITLE
Updated zman names to be more descriptive (and to not break sometimes)

### DIFF
--- a/src/cli_zmanim/default_config.yaml
+++ b/src/cli_zmanim/default_config.yaml
@@ -1,10 +1,10 @@
 Zmanim:
   chatzotNight: False
-  alotHaShachar: False
+  alotHaShachar: True
   misheyakir: False
   misheyakirMachmir: False
   dawn: False
-  sunrise: True
+  sunrise: False
   sofZmanShmaMGA19Point8: False
   sofZmanShmaMGA16Point1: False
   sofZmanShmaMGA: False
@@ -22,9 +22,9 @@ Zmanim:
   candleLighting: True
   sunset: True
   beinHaShmashos: False
-  dusk: True
+  dusk: False
   tzeit7083deg: False
-  tzeit85deg: False
+  tzeit85deg: True
   tzeit42min: False
   tzeit50min: False
   tzeit72min: False

--- a/src/cli_zmanim/helpers.py
+++ b/src/cli_zmanim/helpers.py
@@ -85,7 +85,7 @@ def format_text(string: str) -> str:
     if stripped in names:
         return names[stripped]
     else:
-        print("manually processing")
+        # print("manually processing")
         output_str = ""
         for index, char in enumerate(stripped):
             if index == 0:

--- a/src/cli_zmanim/helpers.py
+++ b/src/cli_zmanim/helpers.py
@@ -1,8 +1,8 @@
-from typing import TextIO
 import datetime
-import yaml
+from typing import TextIO
 
 import requests
+import yaml
 
 
 def read_config(
@@ -23,13 +23,16 @@ def read_config(
         shabbat_start: int = merged["Settings"]["shabbat_start"]
         geonames_id: str = merged["Settings"]["geonames_loc"]
     except TypeError:
-        print("Couldn't properly parse your config.yaml, if you're config file contains an empty category (eg. APIs), try removing it")
+        print(
+            "Couldn't properly parse your config.yaml, if your config file contains an empty category (eg. APIs), try removing it"
+        )
         exit(1)
     return (zmanim, location, geonames_key, shabbat_start, geonames_id)
 
 
 def hebcal_call(location: str, date: str) -> dict:
     api_url = f"https://www.hebcal.com/zmanim?cfg=json&geonameid={location}&date={date}"
+    # print(api_url)
     params = {"cfg": "json"}
     response = requests.get(api_url, params=params)
 
@@ -46,16 +49,53 @@ def hebcal_call(location: str, date: str) -> dict:
 
 
 def format_text(string: str) -> str:
-    output_str = ""
-    for index, char in enumerate(string):
-        if index == 0:
-            output_str += char.upper()
-        elif char.isupper():
-            output_str += " "
-            output_str += char
-        else:
-            output_str += char
-    return output_str
+    names: dict[str, str] = {
+        "chatzotNight": "Chatzot Night",
+        "alotHaShachar": "Alot Hashachar",
+        "misheyakir": "Misheyakir (Earliest Tallit)",
+        "misheyakirMachmir": "Misheyakir (Earliest Tallit; Machmir)",
+        "dawn": "Civil Dawn",
+        "sunrise": "Sunrise",
+        "sofZmanShmaMGA19Point8": "Sof Zman Shma (Magen Avraham 19.8)",
+        "sofZmanShmaMGA16Point1": "Sof Zman Shma (Magen Avraham 16.1)",
+        "sofZmanShmaMGA": "Sof Zman Shma (Magen Avraham 72min)",
+        "sofZmanShma": "Sof Zman Shma (Gra)",
+        "sofZmanTfillaMGA19Point8": "Sof Zman Tfilla (Magen Avraham 19.8)",
+        "sofZmanTfillaMGA16Point1": "Sof Zman Tfilla (Magen Avraham 16.1)",
+        "sofZmanTfillaMGA": "Sof Zman Tfilla (Magen Avraham 72min)",
+        "sofZmanTfilla": "Sof Zman Tfilla (Gra)",
+        "chatzot": "Chatzot",
+        "minchaGedola": "Mincha Gedola (Gra)",
+        "minchaGedolaMGA": "Mincha Gedola (Magen Avraham)",
+        "minchaKetana": "Mincha Ketana (Gra)",
+        "minchaKetanaMGA": "Mincha Ketana (Magen Avraham)",
+        "plagHaMincha": "Plag Hamincha",
+        "sunset": "Sunset",
+        "beinHaShmashos": "Bein Hashmashot",
+        "dusk": "Dusk",
+        "tzeit7083deg": "Tzeit (7.083 degrees)",
+        "tzeit85deg": "Tzeit (8.5 degrees)",
+        "tzeit42min": "tzeit (42 min)",
+        "tzeit50min": "tzeit (50 min)",
+        "tzeit72min": "tzeit (72 min)",
+    }
+
+    stripped: str = string.strip()
+
+    if stripped in names:
+        return names[stripped]
+    else:
+        print("manually processing")
+        output_str = ""
+        for index, char in enumerate(stripped):
+            if index == 0:
+                output_str += char.upper()
+            elif char.isupper():
+                output_str += " "
+                output_str += char
+            else:
+                output_str += char
+        return output_str
 
 
 def friday(dictionary: dict, shabbat: int) -> dict:

--- a/src/cli_zmanim/main.py
+++ b/src/cli_zmanim/main.py
@@ -1,17 +1,18 @@
-import datetime
 import argparse
+import datetime
+import importlib.resources
+import os
 import sys
+from pathlib import Path
 
 import geocoder
-import importlib.resources
-from pathlib import Path
-import os
 from rich.traceback import install
 
-from .helpers import hebcal_call, format_text, read_config, friday
 from .date import print_events
+from .helpers import format_text, friday, hebcal_call, read_config
 
 install()
+
 
 def main():
     # set up parser
@@ -86,7 +87,7 @@ def main():
             sys.exit(1)
 
         location = geonames_obj.geonames_id
-        print(location)
+        # print(location)
 
     date = date_obj.strftime("%Y-%m-%d")
     data = hebcal_call(location, date)

--- a/uv.lock
+++ b/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "cli-zmanim"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "datetime" },
@@ -63,7 +63,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
-    { name = "typer" },
 ]
 
 [package.metadata]
@@ -73,7 +72,6 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "rich", specifier = ">=14.1.0" },
-    { name = "typer", specifier = ">=0.16.0" },
 ]
 
 [[package]]
@@ -268,45 +266,12 @@ wheels = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
-]
-
-[[package]]
-name = "typing-extensions"
-version = "4.14.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Switched from programmatically generating the names displayed for zmanim to using a dictionary, allowing for more descriptive names as well as preventing malformation of certain zmanim names (such as the magen avraham zmanim). Also updated the default zmanim list to include alot instead of civil dawn and Tzeit 8.5 deg (what myzmanim uses) instead of dusk.

